### PR TITLE
Fix useRef error in components

### DIFF
--- a/app/editor/new/page.tsx
+++ b/app/editor/new/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { ErrorPage } from "@/components/error-page"
 import { captureClientError } from "@/lib/client-error-handler"
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ import { NotificationProvider } from "@/contexts/notification-context"
 import { BreadcrumbProvider } from "@/contexts/breadcrumb-context"
 import { Breadcrumb } from "@/components/breadcrumb"
 import { initSentry } from "@/lib/sentry"
-import { Suspense } from "react"
+import { Suspense, useRef } from "react"
 
 // Initialize Sentry
 if (typeof window !== "undefined") {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { getIdeas } from "@/lib/db"
 import { calculateTechnicalFeasibility, calculatePotentialImpact } from "@/lib/ai"
 import { getServerAuthSession } from "@/auth"
 import { setTag } from "@/lib/sentry"
+import { useRef } from "react"
 
 export default async function Home() {
   // Add Sentry tag for this page

--- a/components/audio-recorder.tsx
+++ b/components/audio-recorder.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Button } from "@/components/ui/button"
 import { Mic, MicOff, Play, Pause, Save } from "lucide-react"
 import { startRecording, stopRecording, uploadAudio } from "@/lib/audio"

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useEffect } from "react"
+import { React, useRef, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -42,8 +42,8 @@ export function Search() {
   } = useSearch()
 
   const router = useRouter()
-  const searchRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const searchRef = React.useRef<HTMLDivElement>(null)
+  const inputRef = React.useRef<HTMLInputElement>(null)
 
   // Close search dropdown when clicking outside
   useOnClickOutside(searchRef, () => setIsSearchOpen(false))


### PR DESCRIPTION
Fix the TypeError by importing `useRef` from `react` and replacing `useRef` with `React.useRef` in the components.

* **app/page.tsx**
  - Import `useRef` from `react`
* **app/editor/new/page.tsx**
  - Import `useRef` from `react`
* **app/editor/page.tsx**
  - Import `useRef` from `react`
* **app/error.tsx**
  - Import `useRef` from `react`
* **app/layout.tsx**
  - Import `useRef` from `react`
* **components/audio-recorder.tsx**
  - Import `useRef` from `react`
* **components/search.tsx**
  - Import `useRef` from `react`
  - Replace `useRef` with `React.useRef` in the component

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JustAGhosT/phoenixvc-idea-generator/pull/3?shareId=fa27d78b-8ad3-4bad-a730-332a3a03cd3b).